### PR TITLE
Feature set default language to pt-BR

### DIFF
--- a/src/package/SlateEditor/initialEditorState.js
+++ b/src/package/SlateEditor/initialEditorState.js
@@ -6,7 +6,7 @@ const initialEditorState = {
       kind: 'block',
       type: 'paragraph',
       nodes: [
-        { kind: 'text', text: 'A line of text in a paragraph.' },
+        { kind: 'text', text: 'Uma linha de texto em um parágrafo.' },
       ]
     }
   ]

--- a/src/package/components/modal/Modal.js
+++ b/src/package/components/modal/Modal.js
@@ -11,13 +11,14 @@ const Modal = ({ children }) => (
   </div>
 )
 
-Modal.Header = ({ title = 'Edit', closeButtonAction }) => (
+Modal.Header = ({ title = 'Editar', closeButtonAction }) => (
   <div className="modal--header">
     {title}
     {closeButtonAction && (
       <button
         className="button--close"
         onClick={closeButtonAction}
+        title='Fechar'
       />
     )}
   </div>

--- a/src/package/components/modal/ModalForm.css
+++ b/src/package/components/modal/ModalForm.css
@@ -33,4 +33,5 @@
   color: #999;
   margin-bottom: .5rem;
   line-height: 1rem;
+  text-align: left;
 }

--- a/src/package/components/modal/ModalForm.css
+++ b/src/package/components/modal/ModalForm.css
@@ -27,3 +27,10 @@
 .modal--container .modal--form .modal--form-group input::placeholder {
   color: #ccc;
 }
+
+.modal--container .modal--form .modal--form-label-helper {
+  font-size: .75rem;
+  color: #999;
+  margin-bottom: .5rem;
+  line-height: 1rem;
+}

--- a/src/package/components/modal/ModalForm.js
+++ b/src/package/components/modal/ModalForm.js
@@ -22,4 +22,13 @@ ModalForm.Group = ({ children, className, ...props }) => (
   </div>
 )
 
+ModalForm.LabelHelper = ({ children, className, ...props }) => (
+  <span
+    className={classnames('modal--form-label-helper', className)}
+    {...props}
+  >
+    {children}
+  </span>
+)
+
 export default ModalForm

--- a/src/package/components/tooltip/Tooltip.css
+++ b/src/package/components/tooltip/Tooltip.css
@@ -12,7 +12,7 @@
   font-size: 14px;
   padding: 16px;
   border-radius: 3px;
-  min-width: 260px;
+  min-width: 275px;
   max-height: 290px;
   text-align: left;
   user-select: none;

--- a/src/package/plugins/slate-image-plugin/ImageDataModal.js
+++ b/src/package/plugins/slate-image-plugin/ImageDataModal.js
@@ -48,7 +48,11 @@ class ImageDataModal extends Component {
               changeModalState(false)
             }}>
               <ModalForm.Group>
-                <label htmlFor="image-plugin--edit-title">Title</label>
+                <label htmlFor="image-plugin--edit-title">Título</label>
+                <ModalForm.LabelHelper>
+                  Esta mensagem aparecerá quando o cursor do mouse
+                  estiver posicionado sobre a imagem.
+                </ModalForm.LabelHelper>
                 <input
                   id="image-plugin--edit-title"
                   type="text"
@@ -56,6 +60,7 @@ class ImageDataModal extends Component {
                   onClick={e => e.stopPropagation()}
                   onChange={e => this.setImageAttribute(e, e.target.value)}
                   value={this.state.imageAttributes.title}
+                  placeholder='Insira uma descrição para a imagem'
                 />
               </ModalForm.Group>
 
@@ -68,6 +73,7 @@ class ImageDataModal extends Component {
                   onClick={e => e.stopPropagation()}
                   onChange={e => this.setImageAttribute(e, e.target.value)}
                   value={this.state.imageAttributes.href}
+                  placeholder='Ex: http://dominio.com'
                 />
               </ModalForm.Group>
 
@@ -81,21 +87,21 @@ class ImageDataModal extends Component {
                     onChange={e => this.setImageAttribute(e, e.target.checked)}
                     checked={this.state.imageAttributes.openExternal}
                   />
-                  Open link in new tab
+                  Abrir em nova aba
                 </label>
               </ModalForm.Group>
 
               <ModalButton.Container>
                 <ModalButton.Primary
                   type="submit"
-                  text="Save"
+                  text="Salvar"
                 />
                 <ModalButton.Opaque
-                  text="Cancel"
+                  text="Cancelar"
                   onClick={() => changeModalState(false)}
                 />
                 <ModalButton.Danger
-                  text="Delete"
+                  text="Deletar"
                   onClick={e => {
                     e.preventDefault()
                     e.stopPropagation()

--- a/src/package/plugins/slate-image-plugin/ImageNode.js
+++ b/src/package/plugins/slate-image-plugin/ImageNode.js
@@ -35,7 +35,7 @@ class ImageNode extends Component {
         <div className={classnames('image-node--container', { readonly: readOnly })}>
           <ImageEditLayer
             changeModalState={this.modal.bind(this)}
-            text="Edit"
+            text="Editar"
           />
           <img
             {...attributes}

--- a/src/package/plugins/slate-link-plugin/LinkDataModal.js
+++ b/src/package/plugins/slate-link-plugin/LinkDataModal.js
@@ -92,7 +92,11 @@ class LinkDataModal extends Component {
               changeModalState(false)
             }}>
               <ModalForm.Group>
-                <label htmlFor="image-plugin--edit-title">Title</label>
+                <label htmlFor="image-plugin--edit-title">Título</label>
+                <ModalForm.LabelHelper>
+                  Esta mensagem aparecerá quando o cursor do mouse
+                  estiver posicionado sobre o link.
+                </ModalForm.LabelHelper>
                 <input
                   id="image-plugin--edit-title"
                   type="text"
@@ -100,7 +104,7 @@ class LinkDataModal extends Component {
                   onClick={e => e.stopPropagation()}
                   onChange={e => this.setLinkAttribute(e, e.target.value)}
                   value={this.state.imageAttributes.title}
-                  placeholder="i.e. Hint text"
+                  placeholder="Insira uma descrição para o link"
                 />
               </ModalForm.Group>
 
@@ -113,13 +117,13 @@ class LinkDataModal extends Component {
                   onClick={e => e.stopPropagation()}
                   onChange={e => this.setLinkAttribute(e, e.target.value)}
                   value={this.state.imageAttributes.href}
-                  placeholder="e.g. http://example.com"
+                  placeholder="Ex: http://dominio.com"
                   ref={input => this.inputHref = input}
                 />
               </ModalForm.Group>
 
               <ModalForm.Group>
-                <label htmlFor="image-plugin--edit-text">Text</label>
+                <label htmlFor="image-plugin--edit-text">Texto</label>
                 <input
                   id="image-plugin--edit-text"
                   type="text"
@@ -140,24 +144,24 @@ class LinkDataModal extends Component {
                     onChange={e => this.setLinkAttribute(e, e.target.checked)}
                     checked={this.state.imageAttributes.target === '_blank'}
                   />
-                  Open link in new tab
+                  Abrir em nova aba
                 </label>
               </ModalForm.Group>
 
               <ModalButton.Container>
                 <ModalButton.Primary
                   type="submit"
-                  text="Save"
+                  text="Salvar"
                 />
                 <ModalButton.Opaque
-                  text="Cancel"
+                  text="Cancelar"
                   onClick={() => {
                     if (!node.data.get('href')) onChange(unlink(state))
                     changeModalState(false)
                   }}
                 />
                 <ModalButton.Danger
-                  text="Unlink"
+                  text="Remover link"
                   onClick={e => {
                     e.preventDefault()
                     e.stopPropagation()

--- a/src/package/plugins/slate-link-plugin/LinkDataModal.js
+++ b/src/package/plugins/slate-link-plugin/LinkDataModal.js
@@ -161,7 +161,7 @@ class LinkDataModal extends Component {
                   }}
                 />
                 <ModalButton.Danger
-                  text="Remover link"
+                  text="Remover"
                   onClick={e => {
                     e.preventDefault()
                     e.stopPropagation()

--- a/src/package/plugins/slate-link-plugin/LinkNode.js
+++ b/src/package/plugins/slate-link-plugin/LinkNode.js
@@ -70,7 +70,7 @@ class LinkNode extends Component {
                 Editar
               </Tooltip.Item>
               <Tooltip.Item onClick={() => onChange(unlink(state))}>
-                Remover link
+                Remover
               </Tooltip.Item>
             </Tooltip>
           )}

--- a/src/package/plugins/slate-link-plugin/LinkNode.js
+++ b/src/package/plugins/slate-link-plugin/LinkNode.js
@@ -67,10 +67,10 @@ class LinkNode extends Component {
                 </a>
               </Tooltip.Item>
               <Tooltip.Item onClick={() => this.modal(true)}>
-                Edit
+                Editar
               </Tooltip.Item>
               <Tooltip.Item onClick={() => onChange(unlink(state))}>
-                Unlink
+                Remover link
               </Tooltip.Item>
             </Tooltip>
           )}


### PR DESCRIPTION
# Related issues
- Set default label values to pt-br #31

# How to test
Test cases for each of changed plugins

### Image Plugin
- Insert an image 
- The layer on hover should be in pt-BR

| before   | expected |
|---|---|
| <img width="1098" alt="screen shot 2017-06-20 at 20 18 35" src="https://user-images.githubusercontent.com/5435389/27360171-05eea9e6-55f6-11e7-8012-f38c4d326835.png"> | <img width="1092" alt="screen shot 2017-06-20 at 20 19 38" src="https://user-images.githubusercontent.com/5435389/27360170-05e9c070-55f6-11e7-90d2-5d2432bbe36f.png"> |

- After click on layer to edit, the form texts should be in pt-BR

| before   | expected |
|---|---|
| <img width="811" alt="screen shot 2017-06-20 at 20 20 01" src="https://user-images.githubusercontent.com/5435389/27360224-36bddd94-55f6-11e7-8586-b91911f6b3d1.png"> | <img width="806" alt="screen shot 2017-06-20 at 20 34 35" src="https://user-images.githubusercontent.com/5435389/27360517-ec93ac88-55f7-11e7-9012-d90bf89c3a54.png"> |

### Link Plugin

- Select a text and click on the link button on the toolbar of use keyboard shortcut:
  - Mac: <kbd>cmd</kbd>+<kbd>k</kbd>
  - Win/Linux: <kbd>ctrl</kbd>+<kbd>k</kbd>
- The layer's form texts should be in pt-BR:

| before   | expected |
|---|---|
| <img width="806" alt="screen shot 2017-06-20 at 20 25 20" src="https://user-images.githubusercontent.com/5435389/27360292-a454d5b0-55f6-11e7-82eb-c8b74580e0e3.png"> | <img width="809" alt="screen shot 2017-06-20 at 20 25 33" src="https://user-images.githubusercontent.com/5435389/27360293-a455be58-55f6-11e7-8141-ab38fdabc59b.png"> |

- Click on save or simply hit <kbd>enter</kbd>
- Click on the linked text
- The tooltip should be in pt-BR

| before   | expected |
|---|---|
| <img width="445" alt="screen shot 2017-06-20 at 20 32 00" src="https://user-images.githubusercontent.com/5435389/27360453-95e24ec6-55f7-11e7-89be-7791513a35b8.png"> | <img width="524" alt="screen shot 2017-06-20 at 20 32 15" src="https://user-images.githubusercontent.com/5435389/27360454-95e2f574-55f7-11e7-8bd6-8142bb0cb555.png"> |
