### PR TITLE
Remove focus to apply instantly changes

### DIFF
--- a/src/package/plugins/slate-color-plugin/ColorUtils.js
+++ b/src/package/plugins/slate-color-plugin/ColorUtils.js
@@ -14,12 +14,10 @@ export const reapplyMark = ({ change, rgba }) => {
 
   return change
   .addMark(createMark(rgba))
-  .focus()
 }
 
 export const applyMark = ({ change, rgba }) => change
   .addMark(createMark(rgba))
-  .focus()
 
 /**
  * Strategy that decides how color mark plugin

--- a/src/package/plugins/slate-font-family-plugin/FontFamilyUtils.js
+++ b/src/package/plugins/slate-font-family-plugin/FontFamilyUtils.js
@@ -9,11 +9,9 @@ export const createMark = fontFamilyIndex => ({
 export const reapplyMark = ({ change, fontFamilyIndex }) => change
   .removeMark(getMark(change.state))
   .addMark(createMark(fontFamilyIndex))
-  .focus()
 
 export const applyMark = ({ change, fontFamilyIndex }) => change
   .addMark(createMark(fontFamilyIndex))
-  .focus()
 
 /**
  * Strategy that decides how font family mark plugin

--- a/src/package/plugins/slate-font-size-plugin/FontSizeInput.js
+++ b/src/package/plugins/slate-font-size-plugin/FontSizeInput.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import keycode from 'keycode'
 import classnames from 'classnames'
 
 import { fontSizeStrategy } from './FontSizeUtils'
@@ -17,31 +16,25 @@ if (require('exenv').canUseDOM) require('./FontSizeInput.css')
 //
 const FontSizeInput = ({
   state,
-  onChange,
   className,
   style,
   changeState,
   initialFontSize,
   outerState: { fontSize: fontSizeState },
-}) => {
+}) => { 
   if (!fontSizeState) changeState({ state, fontSize: initialFontSize })
 
   return (
     <input
-      onKeyDown={({ target: { value: fontSizeValue }, keyCode }) => {
-        const fontSize = Number(fontSizeValue)
-        const isEnter = keycode(keyCode) === 'enter'
-
-        // Set new font size to selection
-        if (isEnter) changeState({ fontSize, state: fontSizeStrategy({ change: state.change(), fontSize, changeState }).state })
-        else changeState({ fontSize, state })
-      }}
       onChange={({ target: { value: fontSizeValue } }) => {
         if (Number(fontSizeValue) <= 0) fontSizeValue = '1'
         const fontSize = fontSizeValue || '1'
-
-        // Only handle the input value
-        changeState({ state, fontSize })
+        const fontSizeState = fontSizeStrategy({
+          change: state.change(),
+          fontSize,
+          changeState
+        }).state
+        changeState({ fontSize, state: fontSizeState })
       }}
       onFocus={e => e.target.select()}
       className={classnames('slate-font-size-plugin-input', className)}

--- a/src/package/plugins/slate-font-size-plugin/FontSizeKeyboardShortcut.js
+++ b/src/package/plugins/slate-font-size-plugin/FontSizeKeyboardShortcut.js
@@ -1,5 +1,3 @@
-import keycode from 'keycode'
-
 import { fontSizeIncrease, fontSizeDecrease } from './FontSizeUtils'
 
 
@@ -7,24 +5,14 @@ const FontSizeKeyboardShortcut = (event, data, change, editor, options) => {
   const { changeState } = editor.props
   const { initialFontSize } = options
 
-  const increase = keycode(data.code) === '='
-  const decrease = keycode(data.code) === '-'
-
-  const mac = data.isCmd && data.isCtrl
-  const win = data.isCtrl && data.isAlt
-
-  const isIncreaseMac = mac && increase
-  const isIncreaseWin = win && increase
-  const isIncrease = isIncreaseMac || isIncreaseWin
-
-  const isDecreaseMac = mac && decrease
-  const isDecreaseWin = win && decrease
-  const isDecrease = isDecreaseMac || isDecreaseWin
+  const modShift = data.isMod && data.isShift
+  const isDecrease = modShift && data.key === ','
+  const isIncrease = modShift && data.key === '.'
 
   const fontSize = initialFontSize
 
-  if (isIncrease) return fontSizeIncrease({ change, fontSize, changeState })
   if (isDecrease) return fontSizeDecrease({ change, fontSize, changeState })
+  if (isIncrease) return fontSizeIncrease({ change, fontSize, changeState })
   return
 }
 

--- a/src/package/plugins/slate-font-size-plugin/FontSizeUtils.js
+++ b/src/package/plugins/slate-font-size-plugin/FontSizeUtils.js
@@ -23,7 +23,6 @@ export const fontSizeStrategy = ({ change, fontSize, changeState }) => {
       return change
         .removeMark(getMark(state))
         .addMark(createMark(fontSize))
-        .focus()
     }
     else console.info('[SlateJS][FontSizePlugin] selection collapsed, w/ inline.')
   } else {
@@ -32,7 +31,6 @@ export const fontSizeStrategy = ({ change, fontSize, changeState }) => {
       changeState({ fontSize })
       return change
         .addMark(createMark(fontSize))
-        .focus()
     }
     else console.info('[SlateJS][FontSizePlugin] selection collapsed, w/o inline.')
   }

--- a/src/package/plugins/slate-font-size-plugin/README.md
+++ b/src/package/plugins/slate-font-size-plugin/README.md
@@ -57,10 +57,10 @@ class SlateEditor extends Component {
 
 | Platform                 | Action   | Shortcut       |
 |--------------------------|----------|----------------|
-| ![Apple Logo][apple]     | Increase | `⌘`+`^`+`+`    |
-| ![Apple Logo][apple]     | Decrease | `⌘`+`^`+`-`    |
-| ![Windows Logo][windows] | Increase | `^`+`alt`+`+`  |
-| ![Windows Logo][windows] | Decrease | `^`+`alt`+`-`  |
+| ![Apple Logo][apple]     | Increase | <kbd>⌘</kbd>+<kbd>shift</kbd>+<kbd>></kbd>     |
+| ![Apple Logo][apple]     | Decrease | <kbd>⌘</kbd>+<kbd>shift</kbd>+<kbd><</kbd>     |
+| ![Windows Logo][windows] | Increase | <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>></kbd>  |
+| ![Windows Logo][windows] | Decrease | <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd><</kbd>  |
 
 # API
 


### PR DESCRIPTION
## Plugins

- `slate-font-size-plugin`
- `slate-font-family-plugin`
- `slate-color-plugin`

## Related issues

- Change font size with keyboard [Closes #2]
- I want to see the style I've chosen reflected instantly in the text [Closes #45]

## How to test

When you change a color, font size or font family, should apply instantly the style and keep focus on insert input