### PR TITLE
Support React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dentist": "^1.0.3",
     "enzyme": "^2.4.1",
     "history": "^4.2.0",
+    "prop-types": "^15.6.0",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",

--- a/src/package/plugins/slate-color-plugin/DraggableColorPicker.js
+++ b/src/package/plugins/slate-color-plugin/DraggableColorPicker.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types';
+import React from 'react';
 import Draggable from 'react-draggable'
 import { SketchPicker } from 'react-color'
 


### PR DESCRIPTION
using prop-types package because proptypes no longer supported in React 16.

