### PR TITLE
Hotfix link plugin insertion

### DIFF
--- a/src/package/plugins/slate-link-plugin/LinkUtils.js
+++ b/src/package/plugins/slate-link-plugin/LinkUtils.js
@@ -32,31 +32,16 @@ export const insertLinkStrategy = change => {
   if (hasLinks(value)) {
     change.unwrapInline('link')
   }
+
   else if (value.isExpanded && !hasMultiBlocks(value)) {
-    const { startOffset } = value.selection
-
-    // fix offset 0 selection:
-    // add a single white space and select forward white space
-    if (startOffset === 0) {
-      change
-        .insertText(` ${value.anchorText.text}`)
-        .moveOffsetsTo(1, value.anchorText.characters.size + 1)
-    }
-
     change
       .wrapInline(createLink({ target: '_blank', openModal: true }))
-
-    // fix offset 0 selection:
-    // remove the white space added before
-    if (startOffset === 0) {
-      change
-        .moveOffsetsTo(0, 0)
-        .deleteBackward()
-    }
   }
+
   else if (hasMultiBlocks(value)) {
     console.info('[SlateJS][LinkPlugin] has multiple blocks on selection')
   }
+
   else if (value.isCollapsed && !hasLinks(value)) {
     console.info('[SlateJS][LinkPlugin] selection collapsed, w/o links on selection')
   }

--- a/src/package/plugins/slate-link-plugin/LinkUtils.js
+++ b/src/package/plugins/slate-link-plugin/LinkUtils.js
@@ -18,7 +18,6 @@ export const updateLinkStrategy = ({ change, data: { title, href, text, target }
 
   change
     .insertText(text)
-    .extend(text.length * -1)
     .setInline({
       type: 'link',
       data: { title, href, text, target }
@@ -34,7 +33,7 @@ export const insertLinkStrategy = change => {
     change.unwrapInline('link')
   }
   else if (value.isExpanded && !hasMultiBlocks(value)) {
-    const startOffset = value.selection.startOffset
+    const { startOffset } = value.selection
 
     // fix offset 0 selection:
     // add a single white space and select forward white space


### PR DESCRIPTION
# Related issues
- Insert link at beginning of line results in deuplicate text #42


# Description
There was 2 bugs with link plugin:
1. On insert link when select text forward
1. On insert link when select text on the beginning of the line


# Use cases tests
A list of use cases tests.

## Insert link when select backward
![backward-selection](https://user-images.githubusercontent.com/5435389/35515745-1854997e-04f1-11e8-8bfc-b1b291f91f39.gif)

## Insert link when select forward
![forward-selection](https://user-images.githubusercontent.com/5435389/35515768-28157dba-04f1-11e8-8af6-c5e66c53bde0.gif)

## Insert link on the beginning of the line
![first-word-selection](https://user-images.githubusercontent.com/5435389/35515802-43bd0538-04f1-11e8-8d3a-6dc5abfa5ba8.gif)

## Insert link when select all text on a line
![select-all](https://user-images.githubusercontent.com/5435389/35515838-5cab11b6-04f1-11e8-928e-b24375f17a46.gif)

The fix can be tested in https://slate-editor.staging.bonde.org